### PR TITLE
Remove context-related restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1 - 2025-03-23
+- Remove context-related restrictions.
+  - Before, only `com_content.article` and `com_content.featured` contexts were enabled.
+
 ## 2.0.0 - 2025-03-01
 - Add support for Joomla 4 and Joomla 5 without the Compatibility plugin.
 - Remove support for Joomla 3.x, Joomla 2.5 and Joomla 1.6.

--- a/plg_embed_google_docs_viewer/embed_google_docs_viewer.xml
+++ b/plg_embed_google_docs_viewer/embed_google_docs_viewer.xml
@@ -2,11 +2,11 @@
 <extension type="plugin" group="content" method="upgrade">
     <name>Content - Embed Google Docs Viewer</name>
     <author>Petteri Kivimäki</author>
-    <creationDate>01 Mar 2025</creationDate>
+    <creationDate>23 Mar 2025</creationDate>
     <copyright>(C)2012-2025 Petteri Kivimäki</copyright>
     <license>GNU General Public License version 3; see LICENSE</license>
     <authorEmail>dinky_jackson@hotmail.com</authorEmail>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <description>PLG_EMBED_GOOGLE_DOCS_VIEWER_DESC</description>
 	<namespace path="src">Joomla\Plugin\Content\EmbedGoogleDocsViewer</namespace>
 	<files>

--- a/plg_embed_google_docs_viewer/src/Extension/EmbedGoogleDocsViewer.php
+++ b/plg_embed_google_docs_viewer/src/Extension/EmbedGoogleDocsViewer.php
@@ -32,7 +32,6 @@ class EmbedGoogleDocsViewer extends CMSPlugin implements SubscriberInterface {
 
         // Get arguments - Joomla 4 and Joomla 5 are supported
         [$context, $article, $params, $page] = array_values($event->getArguments());
-        if ($context !== "com_content.article" && $context !== "com_content.featured") return;
 
         $output = $article->text;
         $regex = "#{google_docs}(.*?){/google_docs}#s";


### PR DESCRIPTION
- Remove context-related restrictions.
  - Before, only `com_content.article` and `com_content.featured` contexts were enabled.